### PR TITLE
Hotfix/float error

### DIFF
--- a/CanonicalEquation/CanonicalEquation.Tests/EquationTests.cs
+++ b/CanonicalEquation/CanonicalEquation.Tests/EquationTests.cs
@@ -52,6 +52,7 @@ namespace CanonicalEquation.Lib.Tests
         [Theory]
         [InlineData("x^2=x", "x^2", "x")]
         [InlineData("1.2x(1.2x)=x", "1.44x^2", "x")]
+        [InlineData("1,2x(1.2x)=x", "1.44x^2", "x")]
         [InlineData("x=y", "x", "y")]
         [InlineData("x^2+ 83 + zxy = 4 - ds+2", "x^2+xyz+83", "-ds+6")]
         [InlineData("x^2+ x(a+b)- x^1 = (ab-cd)(ab-1) - 1", "x^2+ax+bx-x", "a^2b^2-abcd-ab+cd-1")]

--- a/CanonicalEquation/CanonicalEquation.Tests/EquationTests.cs
+++ b/CanonicalEquation/CanonicalEquation.Tests/EquationTests.cs
@@ -51,6 +51,7 @@ namespace CanonicalEquation.Lib.Tests
 
         [Theory]
         [InlineData("x^2=x", "x^2", "x")]
+        [InlineData("1.2x(1.2x)=x", "1.44x^2", "x")]
         [InlineData("x=y", "x", "y")]
         [InlineData("x^2+ 83 + zxy = 4 - ds+2", "x^2+xyz+83", "-ds+6")]
         [InlineData("x^2+ x(a+b)- x^1 = (ab-cd)(ab-1) - 1", "x^2+ax+bx-x", "a^2b^2-abcd-ab+cd-1")]

--- a/CanonicalEquation/CanonicalEquation.Tests/ParserTests/SummandParserTests.cs
+++ b/CanonicalEquation/CanonicalEquation.Tests/ParserTests/SummandParserTests.cs
@@ -64,7 +64,12 @@ namespace CanonicalEquation.Lib.Tests.ParserTests
                 new object[] { "x^2y^2", 1, 2, new List<Variable>{ new Variable('x',2), new Variable('y', 2) }},
                 new object[] { "+7.4z^4wy^6", 7.4, 3, new List<Variable>{ new Variable('z',4), new Variable('w'), new Variable('y', 6) }},
                 new object[] { "-a^5b^2c", -1, 3, new List<Variable>{ new Variable('a',5), new Variable('b', 2), new Variable('c') }},
-                new object[] { "-0.001c", -0.001, 1, new List<Variable>{ new Variable('c') }}
+                new object[] { "-0.001c", -0.001, 1, new List<Variable>{ new Variable('c') }},
+                new object[] { "1.2c", 1.2f, 1, new List<Variable>{ new Variable('c') }},
+                new object[] { "-1,53c", -1.53f, 1, new List<Variable>{ new Variable('c') }},
+                new object[] { "-1,222c", -1.222f, 1, new List<Variable>{ new Variable('c') }},
+                new object[] { "-0.0c", 0, 0, new List<Variable>() },
+                new object[] { "-0,0000000001c", -0.0000000001f, 1, new List<Variable>{ new Variable('c') }},
             };
 
         [Theory, MemberData(nameof(ValidVariableTestCases))]

--- a/CanonicalEquation/CanonicalEquation.Tests/PolynomialTests.cs
+++ b/CanonicalEquation/CanonicalEquation.Tests/PolynomialTests.cs
@@ -8,6 +8,7 @@ namespace CanonicalEquation.Lib.Tests
     {
         [Theory]
         [InlineData("x^2+ 83 + zxy", "x^2+xyz+83")]
+        [InlineData("1,3x^2+ 83 + 2.2zxy", "1.3x^2+2.2xyz+83")]
         [InlineData("(ab-cd)(ab-1) - 1", "a^2b^2-abcd-ab+cd-1")]
         [InlineData("x + (x+1)", "2x+1")]
         [InlineData("(((1-2x^2y)))xy", "-2x^3y^2+xy")]
@@ -20,6 +21,9 @@ namespace CanonicalEquation.Lib.Tests
         [InlineData("(x-x(x-x))", "x")]
         [InlineData("(x-x(x-x(x-x)))", "-x^2+x")]
         [InlineData("x-x(x-x)", "x")]
+        [InlineData("x-1.2x(1,1x-x)", "-0.12x^2+x")]
+        [InlineData("-2.5x(3.5x-x)", "-6.25x^2")]
+        [InlineData("-1,1x(1,1x-x)", "-0.11x^2")]
         public void ParseMethod_ValidInitialString_NotValidEquationArgumentException(
             string initialPolymial, string expectedPolymial)
         {

--- a/CanonicalEquation/CanonicalEquation/Entities/Summand.cs
+++ b/CanonicalEquation/CanonicalEquation/Entities/Summand.cs
@@ -49,8 +49,8 @@ namespace CanonicalEquation.Lib.Entities
             var absMultiplier = Math.Abs(Multiplier);
 
             var absMultiplierString = Math.Abs(absMultiplier - 1) < float.Epsilon
-                ? Variables.Any() ? String.Empty : $"{absMultiplier}"
-                : $"{absMultiplier}";
+                ? Variables.Any() ? String.Empty : $"{absMultiplier.ToString("G", System.Globalization.CultureInfo.InvariantCulture)}"
+                : $"{absMultiplier.ToString("G", System.Globalization.CultureInfo.InvariantCulture)}";
 
             var variablesString = Variables
                 .OrderByDescending(x => x.Power)

--- a/CanonicalEquation/CanonicalEquation/Parsers/SummandParser.cs
+++ b/CanonicalEquation/CanonicalEquation/Parsers/SummandParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using CanonicalEquation.Lib.Extensions;
 using CanonicalEquation.Lib.Entities;
@@ -37,7 +38,7 @@ namespace CanonicalEquation.Lib.Parsers
                 multiplierString.Equals(Symbols.Plus.ToString()))
                 multiplierString += "1";
 
-            var multiplier = float.Parse(multiplierString);
+            var multiplier = float.Parse(multiplierString, NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat);
 
             if (Math.Abs(multiplier) < float.Epsilon) return new Summand(0);
 

--- a/CanonicalEquation/CanonicalEquation/Parsers/SummandParser.cs
+++ b/CanonicalEquation/CanonicalEquation/Parsers/SummandParser.cs
@@ -13,7 +13,7 @@ namespace CanonicalEquation.Lib.Parsers
         private const string VariblesRegexGroupName = "varibles";
         private const string PowerRegexGroupName = "power";
 
-        private static readonly string SummandRegexPattern = $@"^(?<{MultiplierRegexGroupName}>[+-]?\d*\.?\d*)(?<{VariblesRegexGroupName}>[a-zA-Z](?<{PowerRegexGroupName}>\^\d+)*)*$";
+        private static readonly string SummandRegexPattern = $@"^(?<{MultiplierRegexGroupName}>[+-]?\d*[\.\,]?\d*)(?<{VariblesRegexGroupName}>[a-zA-Z](?<{PowerRegexGroupName}>\^\d+)*)*$";
         private static readonly Regex SummandRegex = new Regex(SummandRegexPattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
 
@@ -38,7 +38,7 @@ namespace CanonicalEquation.Lib.Parsers
                 multiplierString.Equals(Symbols.Plus.ToString()))
                 multiplierString += "1";
 
-            var multiplier = float.Parse(multiplierString, NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat);
+            var multiplier = float.Parse(multiplierString.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat);
 
             if (Math.Abs(multiplier) < float.Epsilon) return new Summand(0);
 

--- a/CanonicalEquation/CanonicalEquation/Symbols.cs
+++ b/CanonicalEquation/CanonicalEquation/Symbols.cs
@@ -9,9 +9,10 @@
         public const char OpenBracket = '(';
         public const char CloseBracket = ')';
         public const char Dot = '.';
+        public const char Comma = ',';
 
         public const char Space = ' ';
 
-        public static char[] AllowedSymbolsForEquation = new[] { Equality, Minus, Plus, Power, OpenBracket, CloseBracket, Dot, Space };
+        public static char[] AllowedSymbolsForEquation = new[] { Equality, Minus, Plus, Power, OpenBracket, CloseBracket, Dot, Space, Comma };
     }
 }


### PR DESCRIPTION
added: support different formats of float numbers strings (with comma ',' and dot '.' separators)
fixed: float parsing 
